### PR TITLE
Idempotency

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
 
   license: GPLv3
 
-  role_name: macos-hostname
+  role_name: macos_hostname
 
   min_ansible_version: 2.5
 

--- a/tasks/hostname.yml
+++ b/tasks/hostname.yml
@@ -11,6 +11,14 @@
   # returns an error code (d'oh!) with the empty string stdout that we _want_.
   failed_when: false
 
+- name: mh_hostname
+  debug:
+    var: mh_hostname
+
+- name: mh_current_hostname
+  debug:
+    var: mh_current_hostname
+
 - name: Set macOS HostName.
   command: "scutil --set HostName '{{ mh_hostname }}'"
   become: true

--- a/tasks/hostname.yml
+++ b/tasks/hostname.yml
@@ -11,14 +11,6 @@
   # returns an error code (d'oh!) with the empty string stdout that we _want_.
   failed_when: false
 
-- name: mh_hostname
-  debug:
-    var: mh_hostname
-
-- name: mh_current_hostname
-  debug:
-    var: mh_current_hostname
-
 - name: Set macOS HostName.
   command: "scutil --set HostName '{{ mh_hostname }}'"
   become: true

--- a/tasks/hostname.yml
+++ b/tasks/hostname.yml
@@ -18,6 +18,6 @@
     mh_hostname is defined
     or (
       mh_current_hostname.stdout is defined
-      and mh_current_hostname.stdout != mh_current_hostname
+      and mh_current_hostname.stdout != mh_hostname
     )
   notify: clear dns cache

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,12 +3,18 @@
 
 - name: Work out and set macOS HostName.
   include_tasks: "hostname.yml"
-  when: "mh_hostname is defined"
+  when:
+    - mh_hostname is defined
+    - mh_hostname | length > 0
 
 - name: Work out and set macOS LocalHostName.
   include_tasks: "localhostname.yml"
-  when: "mh_localhostname is defined"
+  when:
+    - mh_localhostname is defined
+    - mh_localhostname | length > 0
 
 - name: Work out and set macOS ComputerName.
   include_tasks: "computername.yml"
-  when: "mh_computername is defined"
+  when:
+    - mh_computername is defined
+    - mh_computername | length > 0


### PR DESCRIPTION
achieves idempotency:
 - fixing a when condition when trying to update the HostName: allowing to unset HostName as it's a better practice:
 https://apple.stackexchange.com/questions/30552/os-x-computer-name-not-matching-what-shows-on-terminal
 
 - improving the when conditions on the main.yml file adding the check that the vars are not empty ( ` | length > 0` )

looks like TravisCI is failing because:
"Role names are now limited to contain only lowercase alphanumeric characters, plus ‘_’ and start with an alpha character. https://ansible-lint.readthedocs.io/en/latest/default_rules.html#role-name-does-not-match-a-z-a-z0-9-pattern

so I have changed the role name to `macos_hostname`